### PR TITLE
Optimize Client structure

### DIFF
--- a/pkg/client/internal/abstract/base.go
+++ b/pkg/client/internal/abstract/base.go
@@ -1,0 +1,46 @@
+package abstract
+
+import (
+	"errors"
+	"github.com/iyear/pure-live/model"
+	"github.com/iyear/pure-live/pkg/conf"
+)
+
+type Client struct {
+}
+
+func (c *Client) Plat() string {
+	return conf.PlatAbstract
+}
+
+func (c *Client) GetPlayURL(room string, qn int) (*model.PlayURL, error) {
+	return nil, errors.New("please override the GetPlayURL function")
+}
+
+func (c *Client) GetRoomInfo(room string) (*model.RoomInfo, error) {
+	return nil, errors.New("please override the GetRoomInfo function")
+}
+
+func (c *Client) Host() string {
+	return ""
+}
+
+func (c *Client) Enter(room string) (tp int, data [][]byte, err error) {
+	return 0, nil, errors.New("please override the Enter function")
+}
+
+func (c *Client) Handle(tp int, data []byte) (msg []model.Msg, matched bool, err error) {
+	return nil, false, errors.New("please override the Handle function")
+}
+
+func (c *Client) HeartBeat() (tp int, data []byte, err error) {
+	return 0, nil, errors.New("please override the HeartBeat function")
+}
+
+func (c *Client) SendDanmaku(room string, content string, tp int, color int64) error {
+	return errors.New("please override the SendDanmaku function")
+}
+
+func (c *Client) Stop() {
+
+}

--- a/pkg/client/internal/bilibili/base.go
+++ b/pkg/client/internal/bilibili/base.go
@@ -3,12 +3,15 @@ package bilibili
 import (
 	"github.com/iyear/biligo"
 	"github.com/iyear/pure-live/model"
+	"github.com/iyear/pure-live/pkg/client/internal/abstract"
 	"github.com/iyear/pure-live/pkg/conf"
 	"github.com/iyear/pure-live/pkg/util"
 	"strconv"
 )
 
-type base struct{}
+type base struct {
+	*abstract.Client
+}
 
 func NewBiliBili() (model.Client, error) {
 	if !conf.Account.BiliBili.Enable {

--- a/pkg/client/internal/douyu/base.go
+++ b/pkg/client/internal/douyu/base.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/guonaihong/gout"
 	"github.com/iyear/pure-live/model"
+	"github.com/iyear/pure-live/pkg/client/internal/abstract"
 	"github.com/iyear/pure-live/pkg/conf"
 	"github.com/iyear/pure-live/pkg/request"
 	"github.com/iyear/pure-live/pkg/util"
@@ -17,7 +18,9 @@ import (
 	"time"
 )
 
-type Douyu struct{}
+type Douyu struct {
+	*abstract.Client
+}
 
 func NewDouyu() (model.Client, error) {
 	return &Douyu{}, nil

--- a/pkg/client/internal/egame/base.go
+++ b/pkg/client/internal/egame/base.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 	"github.com/guonaihong/gout"
 	"github.com/iyear/pure-live/model"
+	"github.com/iyear/pure-live/pkg/client/internal/abstract"
 	"github.com/iyear/pure-live/pkg/conf"
 	"github.com/iyear/pure-live/pkg/util"
 	"github.com/tidwall/gjson"
 	"strings"
 )
 
-type EGame struct{}
+type EGame struct {
+	*abstract.Client
+}
 
 func NewEGame() (model.Client, error) {
 	return &EGame{}, nil

--- a/pkg/client/internal/huya/base.go
+++ b/pkg/client/internal/huya/base.go
@@ -7,6 +7,7 @@ import (
 	"github.com/TarsCloud/TarsGo/tars/protocol/codec"
 	"github.com/gorilla/websocket"
 	"github.com/iyear/pure-live/model"
+	"github.com/iyear/pure-live/pkg/client/internal/abstract"
 	"github.com/iyear/pure-live/pkg/client/internal/huya/internal/tars/danmaku"
 	"github.com/iyear/pure-live/pkg/client/internal/huya/internal/tars/online"
 	"github.com/iyear/pure-live/pkg/client/internal/huya/internal/tars/push_msg"
@@ -19,7 +20,9 @@ import (
 
 const hb = "00031d0000690000006910032c3c4c56086f6e6c696e657569660f4f6e557365724865617274426561747d00003c0800010604745265711d00002f0a0a0c1600260036076164725f77617046000b1203aef00f2203aef00f3c426d5202605c60017c82000bb01f9cac0b8c980ca80c20"
 
-type Huya struct{}
+type Huya struct {
+	*abstract.Client
+}
 type H map[string]interface{}
 
 func NewHuya() (model.Client, error) {

--- a/pkg/conf/const.go
+++ b/pkg/conf/const.go
@@ -1,6 +1,7 @@
 package conf
 
 const (
+	PlatAbstract = "abstract"
 	PlatBiliBili = "bilibili"
 	PlatHuya     = "huya"
 	PlatDouyu    = "douyu"


### PR DESCRIPTION
## 优化了 Client 的结构

### 现有的 Client 结构存在一个问题：

当 Client 要添加新功能时，会在 `model.Client` 接口中新增一个函数，假设这个函数为 `Test()` 

想要编译成功，所有的 `Client` 如 `bilibili.Client` 、 `douyu.Client` 都需要立即实现 `Test()` 函数

这样实际上非常麻烦，也容易造成管理混乱。特别是以后支持平台更多，不可能在接口中新增一个函数，马上就去给各个平台实现这个功能，这个问题在后续由不同人维护直播平台接口时尤为突出。

### 解决方案

新增一个抽象 Client 实现 `abstract.Client` ，所有衍生的 `Client` 都去继承它

当在 `model.Client` 接口中新增一个函数 `Test()` 时，只需要在抽象 `abstract.Client` 中添加这个函数的默认实现，就不用去修改 `douyu.Client` 等衍生 `Client` 了